### PR TITLE
Fix unexpected keyword argument 'context'

### DIFF
--- a/src/rp2/rp2_decimal.py
+++ b/src/rp2/rp2_decimal.py
@@ -58,10 +58,10 @@ class RP2Decimal(Decimal):
     def __lt__(self, other: object) -> bool:
         return not self.__ge__(other)
 
-    def __add__(self, other: object) -> "RP2Decimal":
+    def __add__(self, other: object, context=None) -> "RP2Decimal":
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
-        return RP2Decimal(Decimal.__add__(self, other))
+        return RP2Decimal(Decimal.__add__(self, other, context))
 
     def __sub__(self, other: object) -> "RP2Decimal":
         if not isinstance(other, Decimal):

--- a/src/rp2/rp2_decimal.py
+++ b/src/rp2/rp2_decimal.py
@@ -34,97 +34,97 @@ class RP2Decimal(Decimal):
     def is_equal_within_precision(cls, first: "RP2Decimal", second: "RP2Decimal", precision_mask: Decimal) -> bool:
         return (first - second).quantize(precision_mask) == ZERO
 
-    def __eq__(self, other: object) -> bool:
+    def __eq__(self, other: object, context = None) -> bool:
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
-        return (self - other).quantize(CRYPTO_DECIMAL_MASK).__eq__(ZERO)
+        return (self - other).quantize(CRYPTO_DECIMAL_MASK).__eq__(ZERO, context)
 
-    def __ne__(self, other: object) -> bool:
-        return not self.__eq__(other)
+    def __ne__(self, other: object, context = None) -> bool:
+        return not self.__eq__(other, context)
 
-    def __ge__(self, other: object) -> bool:
+    def __ge__(self, other: object, context = None) -> bool:
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
-        return (self - other).quantize(CRYPTO_DECIMAL_MASK).__ge__(ZERO)
+        return (self - other).quantize(CRYPTO_DECIMAL_MASK).__ge__(ZERO, context)
 
-    def __gt__(self, other: object) -> bool:
+    def __gt__(self, other: object, context = None) -> bool:
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
-        return (self - other).quantize(CRYPTO_DECIMAL_MASK).__gt__(ZERO)
+        return (self - other).quantize(CRYPTO_DECIMAL_MASK).__gt__(ZERO, context)
 
-    def __le__(self, other: object) -> bool:
-        return not self.__gt__(other)
+    def __le__(self, other: object, context = None) -> bool:
+        return not self.__gt__(other, context)
 
-    def __lt__(self, other: object) -> bool:
-        return not self.__ge__(other)
+    def __lt__(self, other: object, context = None) -> bool:
+        return not self.__ge__(other, context)
 
     def __add__(self, other: object, context=None) -> "RP2Decimal":
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
         return RP2Decimal(Decimal.__add__(self, other, context))
 
-    def __sub__(self, other: object) -> "RP2Decimal":
+    def __sub__(self, other: object, context = None) -> "RP2Decimal":
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
-        return RP2Decimal(Decimal.__sub__(self, other))
+        return RP2Decimal(Decimal.__sub__(self, other, context))
 
-    def __mul__(self, other: object) -> "RP2Decimal":
+    def __mul__(self, other: object, context = None) -> "RP2Decimal":
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
-        return RP2Decimal(Decimal.__mul__(self, other))
+        return RP2Decimal(Decimal.__mul__(self, other, context))
 
-    def __truediv__(self, other: object) -> "RP2Decimal":
+    def __truediv__(self, other: object, context = None) -> "RP2Decimal":
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
-        return RP2Decimal(Decimal.__truediv__(self, other))
+        return RP2Decimal(Decimal.__truediv__(self, other, context))
 
-    def __floordiv__(self, other: object) -> "RP2Decimal":
+    def __floordiv__(self, other: object, context = None) -> "RP2Decimal":
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
-        return RP2Decimal(Decimal.__floordiv__(self, other))
+        return RP2Decimal(Decimal.__floordiv__(self, other, context))
 
-    def __pow__(self, other: object, modulo: object = None) -> "RP2Decimal":
+    def __pow__(self, other: object, modulo: object = None, context = None) -> "RP2Decimal":
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
         if modulo is not None and not isinstance(modulo, Decimal):
             raise RP2TypeError(f"Modulo has non-Decimal value {repr(other)}")
-        return RP2Decimal(Decimal.__pow__(self, other, modulo))
+        return RP2Decimal(Decimal.__pow__(self, other, modulo, context))
 
-    def __mod__(self, other: object) -> "RP2Decimal":
+    def __mod__(self, other: object, context = None) -> "RP2Decimal":
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
-        return RP2Decimal(Decimal.__mod__(self, other))
+        return RP2Decimal(Decimal.__mod__(self, other, context))
 
     # Reflected operand overrides
-    def __radd__(self, other: object) -> "RP2Decimal":
+    def __radd__(self, other: object, context = None) -> "RP2Decimal":
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
-        return RP2Decimal(Decimal.__radd__(self, other))
+        return RP2Decimal(Decimal.__radd__(self, other, context))
 
-    def __rsub__(self, other: object) -> "RP2Decimal":
+    def __rsub__(self, other: object, context = None) -> "RP2Decimal":
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
-        return RP2Decimal(Decimal.__rsub__(self, other))
+        return RP2Decimal(Decimal.__rsub__(self, other, context))
 
-    def __rmul__(self, other: object) -> "RP2Decimal":
+    def __rmul__(self, other: object, context = None) -> "RP2Decimal":
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
-        return RP2Decimal(Decimal.__rmul__(self, other))
+        return RP2Decimal(Decimal.__rmul__(self, other, context))
 
-    def __rtruediv__(self, other: object) -> "RP2Decimal":
+    def __rtruediv__(self, other: object, context = None) -> "RP2Decimal":
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
-        return RP2Decimal(Decimal.__rtruediv__(self, other))
+        return RP2Decimal(Decimal.__rtruediv__(self, other, context))
 
-    def __rfloordiv__(self, other: object) -> "RP2Decimal":
+    def __rfloordiv__(self, other: objec, context = None) -> "RP2Decimal":
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
-        return RP2Decimal(Decimal.__rfloordiv__(self, other))
+        return RP2Decimal(Decimal.__rfloordiv__(self, other, context))
 
-    def __rmod__(self, other: object) -> "RP2Decimal":
+    def __rmod__(self, other: objec, context = None) -> "RP2Decimal":
         if not isinstance(other, Decimal):
             raise RP2TypeError(f"Operand has non-Decimal value {repr(other)}")
-        return RP2Decimal(Decimal.__rmod__(self, other))
+        return RP2Decimal(Decimal.__rmod__(self, other, context))
 
 
 ZERO: RP2Decimal = RP2Decimal("0")


### PR DESCRIPTION
Updates signature of `RP2Decimal.__add__()` to allow the `context` param which is
being invoked at
https://github.com/python/cpython/blob/f33e2c87a83917b5139d97fd8ef7cba7223ebef5/Lib/_pydecimal.py#L1257

Fixes #25