### PR TITLE
Add Python 3.11 to test matrix

### DIFF
--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
     env:
       PYTHONPATH: ./src:./test
     steps:

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
     env:
       PYTHONPATH: .\src;.\test
     steps:


### PR DESCRIPTION
https://github.com/eprbell/rp2/commit/0d7b01a7649d8f50c65c28c85e323e92ad5ce2d5, but for Python 3.11. I tried running this on Arch Linux with Python 3.11 and ran into issues immediately; it would be comforting to know that 3.11 is also supported.

CI appears to have passed in my fork, so I will continue doing some research into what went wrong for me.

edit: my issue is the same as https://github.com/eprbell/rp2/issues/25