### PR TITLE
Add note about `mpdecimal` requirement on some Unix platforms

### DIFF
--- a/src/rp2/rp2_main.py
+++ b/src/rp2/rp2_main.py
@@ -68,6 +68,13 @@ def _rp2_main_internal(country: AbstractCountry) -> None:  # pylint: disable=too
 
     _setup_paths(parser=parser, configuration_file=args.configuration_file, input_file=args.input_file, output_dir=args.output_dir)
 
+    # On certain platforms the mpdecimal system library is missing (see details at: https://github.com/eprbell/rp2/issues/25).
+    try:
+        import _decimal as _  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        LOGGER.error("The `mpdecimal` library is a required system dependency for RP2, but Python was not able to locate it.")
+        sys.exit(1)
+
     try:
         LOGGER.info("Country: %s", country.country_iso_code)
         LOGGER.info("Generation Language: %s", args.generation_language)


### PR DESCRIPTION
https://github.com/eprbell/rp2/issues/25#issuecomment-2008647693

`mpdecimal` can't really be added as a dependency of RP2 since it's a system library rather than a Python package, but at least we can document it in the installation/setup instructions.