### PR TITLE
Add more output to acquired lots exhausted exception.

### DIFF
--- a/src/rp2/balance.py
+++ b/src/rp2/balance.py
@@ -28,7 +28,6 @@ from rp2.out_transaction import OutTransaction
 from rp2.rp2_decimal import ZERO, RP2Decimal
 from rp2.rp2_error import RP2TypeError, RP2ValueError
 
-
 CRYPTO_BALANCE_DECIMAL_MASK: Decimal = Decimal("1." + "0" * 10)
 
 
@@ -146,7 +145,7 @@ class BalanceSet:
             ):
                 raise RP2ValueError(
                     f'{intra_transaction.asset} balance of account "{from_account.exchange}" (holder "{from_account.holder}") went negative '
-                    f'({final_balances[from_account]}) on the following transaction: {intra_transaction}'
+                    f"({final_balances[from_account]}) on the following transaction: {intra_transaction}"
                 )
 
         # Balances for sold and gifted currency
@@ -164,7 +163,7 @@ class BalanceSet:
             ):
                 raise RP2ValueError(
                     f'{out_transaction.asset} balance of account "{from_account.exchange}" (holder "{from_account.holder}") went negative '
-                    f'({final_balances[from_account]}) on the following transaction: {out_transaction}'
+                    f"({final_balances[from_account]}) on the following transaction: {out_transaction}"
                 )
 
         for account, final_balance in final_balances.items():

--- a/src/rp2/gain_loss_set.py
+++ b/src/rp2/gain_loss_set.py
@@ -204,9 +204,11 @@ class GainLossSet(AbstractEntrySet):
                 LOGGER.debug(
                     "%s (%d - %d): taxable event housekeeping",
                     last_gain_loss_with_acquired_lot.internal_id,
-                    current_acquired_lot_fraction[last_gain_loss_with_acquired_lot.acquired_lot]
-                    if last_gain_loss_with_acquired_lot.acquired_lot in current_acquired_lot_fraction
-                    else 0,
+                    (
+                        current_acquired_lot_fraction[last_gain_loss_with_acquired_lot.acquired_lot]
+                        if last_gain_loss_with_acquired_lot.acquired_lot in current_acquired_lot_fraction
+                        else 0
+                    ),
                     current_taxable_event_fraction,
                 )
 

--- a/src/rp2/tax_engine.py
+++ b/src/rp2/tax_engine.py
@@ -194,7 +194,10 @@ def _create_unfiltered_gain_and_loss_set(
                 )
 
     except AcquiredLotsExhaustedException:
-        raise RP2ValueError("Total in-transaction crypto value < total taxable crypto value") from None
+        raise RP2ValueError(
+            f"Total in-transaction crypto value ({acquired_lot_amount}) - total taxable crypto value ({taxable_event_amount}) went negative "
+            f"({acquired_lot_amount - taxable_event_amount}) on the following event: {taxable_event}"
+        ) from None
     except TaxableEventsExhaustedException:
         pass
 

--- a/tests/test_tax_engine.py
+++ b/tests/test_tax_engine.py
@@ -123,12 +123,29 @@ class TestTaxEngine(unittest.TestCase):
             )
         )
 
-        with self.assertRaisesRegex(RP2ValueError, "Total in-transaction crypto value < total taxable crypto value"):
+        with self.assertRaises(RP2ValueError) as value_error:
             compute_tax(
                 self._good_input_configuration,
                 self._accounting_engine,
                 input_data,
             )
+        self.assertEqual(
+            str(value_error.exception),
+            """Total in-transaction crypto value (4.98000000000) - total taxable crypto value (21.2) went negative (-16.22000000000) on the following event: \
+OutTransaction:
+  id=38
+  timestamp=2020-06-01 03:59:59.000000 -0400
+  asset=B4
+  exchange=Coinbase Pro
+  holder=Bob
+  transaction_type=TransactionType.SELL
+  spot_price=900.9000
+  crypto_out_no_fee=20.20000000
+  crypto_fee=1.00000000
+  unique_id=
+  is_taxable=True
+  fiat_taxable_amount=18198.1800""",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The current output of AcquiredLotsExhaustedException is not helpful enough to the user.  If they missed a transaction, had a typo in a transaction, or rounding errors are accumulating from the data provided by the exchange, the user will need to manually process their transaction history to find when the exception occurred.

The new output of AcquiredLotsExhaustedException will provide the calculation result and the offending location in the transaction history.

black src tests reformatting is also included.