### PR TITLE
Make FIFO accounting_method linear time

### DIFF
--- a/src/rp2/abstract_accounting_method.py
+++ b/src/rp2/abstract_accounting_method.py
@@ -38,12 +38,22 @@ class AcquiredLotCandidates:
         accounting_method: "AbstractAccountingMethod",
         acquired_lot_list: List[InTransaction],
         acquired_lot_2_partial_amount: Dict[InTransaction, RP2Decimal],
-        up_to_index: int,
     ) -> None:
         self.__accounting_method: AbstractAccountingMethod = accounting_method
         self.__acquired_lot_list = acquired_lot_list
         self.__acquired_lot_2_partial_amount = acquired_lot_2_partial_amount
+        self.__up_to_index = 0
+        self.__from_index = 0
+
+    def set_up_to_index(self, up_to_index: int) -> None:
         self.__up_to_index = up_to_index
+
+    def set_from_index(self, from_index: int) -> None:
+        self.__from_index = from_index
+
+    @property
+    def from_index(self) -> int:
+        return self.__from_index
 
     def has_partial_amount(self, acquired_lot: InTransaction) -> bool:
         return acquired_lot in self.__acquired_lot_2_partial_amount
@@ -60,14 +70,14 @@ class AcquiredLotCandidates:
         self.set_partial_amount(acquired_lot, ZERO)
 
     def __iter__(self) -> "AccountingMethodIterator":
-        return AccountingMethodIterator(self.__acquired_lot_list, self.__up_to_index, self.__accounting_method.lot_candidates_order())
+        return AccountingMethodIterator(self.__acquired_lot_list, self.__from_index, self.__up_to_index, self.__accounting_method.lot_candidates_order())
 
 
 class AccountingMethodIterator:
-    def __init__(self, acquired_lot_list: List[InTransaction], up_to_index: int, order_type: AcquiredLotCandidatesOrder) -> None:
+    def __init__(self, acquired_lot_list: List[InTransaction], from_index: int, up_to_index: int, order_type: AcquiredLotCandidatesOrder) -> None:
         self.__acquired_lot_list = acquired_lot_list
-        self.__start_index = 0 if order_type == AcquiredLotCandidatesOrder.OLDER_TO_NEWER else up_to_index
-        self.__end_index = up_to_index if order_type == AcquiredLotCandidatesOrder.OLDER_TO_NEWER else 0
+        self.__start_index = from_index if order_type == AcquiredLotCandidatesOrder.OLDER_TO_NEWER else up_to_index
+        self.__end_index = up_to_index if order_type == AcquiredLotCandidatesOrder.OLDER_TO_NEWER else from_index
         self.__step = 1 if order_type == AcquiredLotCandidatesOrder.OLDER_TO_NEWER else -1
         self.__index = self.__start_index
         self.__order_type = order_type

--- a/src/rp2/abstract_accounting_method.py
+++ b/src/rp2/abstract_accounting_method.py
@@ -42,11 +42,11 @@ class AcquiredLotCandidates:
         self.__accounting_method: AbstractAccountingMethod = accounting_method
         self.__acquired_lot_list = acquired_lot_list
         self.__acquired_lot_2_partial_amount = acquired_lot_2_partial_amount
-        self.__up_to_index = 0
+        self.__to_index = 0
         self.__from_index = 0
 
-    def set_up_to_index(self, up_to_index: int) -> None:
-        self.__up_to_index = up_to_index
+    def set_to_index(self, to_index: int) -> None:
+        self.__to_index = to_index
 
     def set_from_index(self, from_index: int) -> None:
         self.__from_index = from_index
@@ -70,14 +70,14 @@ class AcquiredLotCandidates:
         self.set_partial_amount(acquired_lot, ZERO)
 
     def __iter__(self) -> "AccountingMethodIterator":
-        return AccountingMethodIterator(self.__acquired_lot_list, self.__from_index, self.__up_to_index, self.__accounting_method.lot_candidates_order())
+        return AccountingMethodIterator(self.__acquired_lot_list, self.__from_index, self.__to_index, self.__accounting_method.lot_candidates_order())
 
 
 class AccountingMethodIterator:
-    def __init__(self, acquired_lot_list: List[InTransaction], from_index: int, up_to_index: int, order_type: AcquiredLotCandidatesOrder) -> None:
+    def __init__(self, acquired_lot_list: List[InTransaction], from_index: int, to_index: int, order_type: AcquiredLotCandidatesOrder) -> None:
         self.__acquired_lot_list = acquired_lot_list
-        self.__start_index = from_index if order_type == AcquiredLotCandidatesOrder.OLDER_TO_NEWER else up_to_index
-        self.__end_index = up_to_index if order_type == AcquiredLotCandidatesOrder.OLDER_TO_NEWER else from_index
+        self.__start_index = from_index if order_type == AcquiredLotCandidatesOrder.OLDER_TO_NEWER else to_index
+        self.__end_index = to_index if order_type == AcquiredLotCandidatesOrder.OLDER_TO_NEWER else from_index
         self.__step = 1 if order_type == AcquiredLotCandidatesOrder.OLDER_TO_NEWER else -1
         self.__index = self.__start_index
         self.__order_type = order_type

--- a/src/rp2/accounting_engine.py
+++ b/src/rp2/accounting_engine.py
@@ -207,18 +207,18 @@ class AccountingEngine:
                 raise RP2RuntimeError("Internal error: acquired_lot incongruence in accounting logic")
             method = self._get_accounting_method(taxable_event.timestamp.year)
             lot_candidates: Optional[AcquiredLotCandidates] = self.__years_2_lot_candidates.find_max_value_less_than(taxable_event.timestamp.year)
-            # lot_candidates is 1:1 with acquired_lot_and_index
-            assert lot_candidates is not None
-            lot_candidates.set_to_index(acquired_lot_and_index.index)
-            acquired_lot_and_amount: Optional[AcquiredLotAndAmount] = method.seek_non_exhausted_acquired_lot(
-                lot_candidates, taxable_event, new_taxable_event_amount
-            )
-            if acquired_lot_and_amount:
-                return TaxableEventAndAcquiredLot(
-                    taxable_event=taxable_event,
-                    acquired_lot=acquired_lot_and_amount.acquired_lot,
-                    taxable_event_amount=new_taxable_event_amount,
-                    acquired_lot_amount=acquired_lot_and_amount.amount,
+            # lot_candidates is 1:1 with acquired_lot_and_index, should always be True
+            if lot_candidates:
+                lot_candidates.set_to_index(acquired_lot_and_index.index)
+                acquired_lot_and_amount: Optional[AcquiredLotAndAmount] = method.seek_non_exhausted_acquired_lot(
+                    lot_candidates, taxable_event, new_taxable_event_amount
                 )
+                if acquired_lot_and_amount:
+                    return TaxableEventAndAcquiredLot(
+                        taxable_event=taxable_event,
+                        acquired_lot=acquired_lot_and_amount.acquired_lot,
+                        taxable_event_amount=new_taxable_event_amount,
+                        acquired_lot_amount=acquired_lot_and_amount.amount,
+                    )
 
         raise AcquiredLotsExhaustedException()

--- a/src/rp2/accounting_engine.py
+++ b/src/rp2/accounting_engine.py
@@ -207,18 +207,18 @@ class AccountingEngine:
                 raise RP2RuntimeError("Internal error: acquired_lot incongruence in accounting logic")
             method = self._get_accounting_method(taxable_event.timestamp.year)
             lot_candidates: Optional[AcquiredLotCandidates] = self.__years_2_lot_candidates.find_max_value_less_than(taxable_event.timestamp.year)
-
-            if lot_candidates:
-                lot_candidates.set_to_index(acquired_lot_and_index.index)
-                acquired_lot_and_amount: Optional[AcquiredLotAndAmount] = method.seek_non_exhausted_acquired_lot(
-                    lot_candidates, taxable_event, new_taxable_event_amount
+            # lot_candidates is 1:1 with acquired_lot_and_index
+            assert lot_candidates is not None
+            lot_candidates.set_to_index(acquired_lot_and_index.index)
+            acquired_lot_and_amount: Optional[AcquiredLotAndAmount] = method.seek_non_exhausted_acquired_lot(
+                lot_candidates, taxable_event, new_taxable_event_amount
+            )
+            if acquired_lot_and_amount:
+                return TaxableEventAndAcquiredLot(
+                    taxable_event=taxable_event,
+                    acquired_lot=acquired_lot_and_amount.acquired_lot,
+                    taxable_event_amount=new_taxable_event_amount,
+                    acquired_lot_amount=acquired_lot_and_amount.amount,
                 )
-                if acquired_lot_and_amount:
-                    return TaxableEventAndAcquiredLot(
-                        taxable_event=taxable_event,
-                        acquired_lot=acquired_lot_and_amount.acquired_lot,
-                        taxable_event_amount=new_taxable_event_amount,
-                        acquired_lot_amount=acquired_lot_and_amount.amount,
-                    )
 
         raise AcquiredLotsExhaustedException()

--- a/src/rp2/accounting_engine.py
+++ b/src/rp2/accounting_engine.py
@@ -209,7 +209,7 @@ class AccountingEngine:
             lot_candidates: Optional[AcquiredLotCandidates] = self.__years_2_lot_candidates.find_max_value_less_than(taxable_event.timestamp.year)
 
             if lot_candidates:
-                lot_candidates.set_up_to_index(acquired_lot_and_index.index)
+                lot_candidates.set_to_index(acquired_lot_and_index.index)
                 acquired_lot_and_amount: Optional[AcquiredLotAndAmount] = method.seek_non_exhausted_acquired_lot(
                     lot_candidates, taxable_event, new_taxable_event_amount
                 )

--- a/src/rp2/accounting_engine.py
+++ b/src/rp2/accounting_engine.py
@@ -199,17 +199,17 @@ class AccountingEngine:
         acquired_lot_amount: RP2Decimal,
     ) -> TaxableEventAndAcquiredLot:
         new_taxable_event_amount: RP2Decimal = taxable_event_amount - acquired_lot_amount
-        avl_result: Optional[_AcquiredLotAndIndex] = self.__acquired_lot_avl.find_max_value_less_than(
+        acquired_lot_and_index: Optional[_AcquiredLotAndIndex] = self.__acquired_lot_avl.find_max_value_less_than(
             self._get_avl_node_key_with_max_disambiguator(taxable_event.timestamp)
         )
-        if avl_result is not None:
-            if avl_result.acquired_lot != self.__acquired_lot_list[avl_result.index]:
+        if acquired_lot_and_index is not None:
+            if acquired_lot_and_index.acquired_lot != self.__acquired_lot_list[acquired_lot_and_index.index]:
                 raise RP2RuntimeError("Internal error: acquired_lot incongruence in accounting logic")
             method = self._get_accounting_method(taxable_event.timestamp.year)
             lot_candidates: Optional[AcquiredLotCandidates] = self.__years_2_lot_candidates.find_max_value_less_than(taxable_event.timestamp.year)
 
             if lot_candidates:
-                lot_candidates.set_up_to_index(avl_result.index)
+                lot_candidates.set_up_to_index(acquired_lot_and_index.index)
                 acquired_lot_and_amount: Optional[AcquiredLotAndAmount] = method.seek_non_exhausted_acquired_lot(
                     lot_candidates, taxable_event, new_taxable_event_amount
                 )

--- a/src/rp2/plugin/accounting_method/fifo.py
+++ b/src/rp2/plugin/accounting_method/fifo.py
@@ -38,7 +38,7 @@ class AccountingMethod(AbstractAccountingMethod):
         selected_acquired_lot_amount: RP2Decimal = ZERO
         selected_acquired_lot: Optional[InTransaction] = None
         acquired_lot: InTransaction
-        # This loop avoids O(m*n) complexity by keeping track of the index of the most recently exhausted lot.
+        # The FIFO plugin features linear complexity by setting lot_candidates from_index to the first non-exhausted lot (to_index is set in the caller).
         # As FIFO ensures no non-exhausted lots can exist to the left of this index, this approach is O(n).
         for acquired_lot in lot_candidates:
             acquired_lot_amount: RP2Decimal = ZERO


### PR DESCRIPTION
The `FIFO` accounting method is unfortunately quadratic time, even in trivial cases:
```
One In, One Out
          FIFO      LIFO      HIFO
1     0.000234  0.000234  0.000231
10    0.001319  0.001319  0.001431
100   0.020807  0.013064  0.022888
1000  1.073289  0.129614  1.145311

Buys, then Sells
          FIFO      LIFO      HIFO
1     0.000225  0.000236  0.000239
10    0.001399  0.001412  0.001534
100   0.022002  0.023371  0.031054
1000  1.119583  1.103518  1.977542
```
The "One In, One Out" alternates `n` pairs of `BUY, SELL` such that there is only ever `k=1` active lots. This represents the most trivial case for any accounting method. A potential worst case is represented by "Buys, then Sells" which creates `n` `BUYS` followed by `n` `SELLS`. This creates a worst case scenario of `k=n`.

In the first case, the `LIFO` method is roughly linear; in the second case, it is clearly quadratic. The quadratic behavior of `LIFO` and `HIFO` will be addressed in a separate PR by using `heapq`.

It is relatively straightforward to make `FIFO` linear time in both of these cases by simply advancing an index of the next, un-exhausted lot on `AcquiredLotCandidates` and persisting this object between invocations of `get_acquired_lot_for_taxable_event()`. In the event of different accounting methods being used for different tax years, a one-time scan is performed for each switch of accounting method to find the appropriate index.

With this PR, `FIFO` performance improves to linear time in both cases:
```
One In, One Out
          FIFO      LIFO      HIFO
1     0.000245  0.000248  0.000242
10    0.001359  0.001396  0.001423
100   0.012248  0.012903  0.022407
1000  0.127431  0.133112  1.161365

Buys, then Sells
          FIFO      LIFO      HIFO
1     0.000233  0.000258  0.000243
10    0.001345  0.001436  0.001533
100   0.012368  0.023112  0.031476
1000  0.129783  1.185451  2.029749
```