### PR TITLE
Replace USD with CURRENCY_CODE in rp2_full_report.py

### DIFF
--- a/src/rp2/plugin/report/rp2_full_report.py
+++ b/src/rp2/plugin/report/rp2_full_report.py
@@ -212,8 +212,8 @@ class Generator(AbstractODSGenerator):
             _("Capital"),
             _("Transaction"),
             _("Crypto"),
-            _("USD"),
-            _("USD Total"),
+            _("{}").format(currency_code),
+            _("{} Total").format(currency_code),
         ]
 
         self.__yearly_gain_loss_summary_header_names_row_2: List[str] = [


### PR DESCRIPTION
The sheet Summary of the full report had "USD" currency code hard-coded in the headings. Replacing with reference to CURRENCY_CODE instead. Tested with rp2_generic plugin.